### PR TITLE
Changed threads to be daemons. Changed minimum Python version

### DIFF
--- a/micromelon/_robot_comms/_robot_communicator_threaded.py
+++ b/micromelon/_robot_comms/_robot_communicator_threaded.py
@@ -31,6 +31,7 @@ class RobotCommunicatorThread(threading.Thread):
     def __init__(self) -> None:
         super().__init__()
 
+        self.daemon = True
         self._commandQueue = None
         self._eventQueue = None
         self._loop = None

--- a/micromelon/_robot_comms/ble/_ble_controller_threadwrapped.py
+++ b/micromelon/_robot_comms/ble/_ble_controller_threadwrapped.py
@@ -16,6 +16,7 @@ class BleControllerThread(threading.Thread):
     def __init__(self, packetReceivedCallback, connectionStatusCallback) -> None:
         super().__init__()
 
+        self.daemon = True
         self._packetReceivedCallback = packetReceivedCallback
         self._connectionStatusCallback = connectionStatusCallback
         self._commandQueue = None

--- a/micromelon/_robot_comms/transports/_robot_transport_serial.py
+++ b/micromelon/_robot_comms/transports/_robot_transport_serial.py
@@ -29,6 +29,7 @@ class RobotTransportSerial(RobotTransportBase):
         self._connection.flushInput()
         self._connection.flushOutput()
         self._readingThread = threading.Thread(target=self._readingRoutine, args=())
+        self._readingThread.setDaemon(True)
         self._readingThread.start()
         self._connectionStatusCallback(CONNECTION_STATUS.CONNECTED)
 

--- a/micromelon/_robot_comms/transports/_robot_transport_tcp.py
+++ b/micromelon/_robot_comms/transports/_robot_transport_tcp.py
@@ -31,5 +31,6 @@ class RobotTransportTCP(RobotTransportSerial):
         # self._connection.flushOutput()
 
         self._readingThread = threading.Thread(target=self._readingRoutine, args=())
+        self._readingThread.setDaemon(True)
         self._readingThread.start()
         self._connectionStatusCallback(CONNECTION_STATUS.CONNECTED)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,14 +23,13 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
 package_dir =
     = .
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     bleak >= 0.11.0
     pyserial


### PR DESCRIPTION
Fixed issue where the robot communication threads were left running after an exception that closed the main-thread.

Changed minimum required python version to 3.8, as 3.7's version of asyncio was incompatible.